### PR TITLE
[fix] 확률 버그 수정

### DIFF
--- a/Assets/1.Scene/SampleScene.unity
+++ b/Assets/1.Scene/SampleScene.unity
@@ -299,6 +299,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1162053630
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1716332810115994517, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_Name
+      value: TestPercent
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8754261
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.40821788
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.23456968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.10938163
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7775561477047763524, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4f3875335fc8c534dad4826b7ac5da27, type: 3}
 --- !u!1 &1518048623
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/3.Script/Develop/KDI/SlotController.cs
+++ b/Assets/3.Script/Develop/KDI/SlotController.cs
@@ -82,6 +82,7 @@ public class SlotController : MonoBehaviour
 
     IEnumerator MakeMove() //슬롯 보여주는 용(only)
     {
+        int a = fixCount;
         for (int i = 0; i < maxSlotCount; i++)
         {
             transform.GetChild(6).GetComponent<Text>().text = "이동 판정 : " + success;
@@ -109,6 +110,7 @@ public class SlotController : MonoBehaviour
             }
         }
             transform.GetChild(6).GetComponent<Text>().text = "이동 판정 : " + success;
+        fixCount = a;
     }
 
 }

--- a/Assets/3.Script/Develop/KDI/SuccessCalc.cs
+++ b/Assets/3.Script/Develop/KDI/SuccessCalc.cs
@@ -38,12 +38,17 @@ public class SuccessCalc : MonoBehaviour
         }
         SlotController.instance.percent = percent;
         maxSlot = maxSlot - testFix;
+
         for (int i = maxSlot; i >= 0; i--)
         {
             float successPercent = percent * (float)0.01;
             float failPercent = (100 - percent) * (float)0.01;
             float result = Mathf.Pow(failPercent, maxSlot - i) * Mathf.Pow(successPercent, maxSlot - (maxSlot - i)) * formula.Combination(maxSlot, i) * 100;
             result = Mathf.Round(result);
+            if (maxSlot <= 0)
+            {
+                result = 100;
+            }
             if (i >= successLimit - testFix)
             {
                 Debug.Log(i + testFix + " " + result + "% ¼º°ø");
@@ -70,6 +75,10 @@ public class SuccessCalc : MonoBehaviour
     public void FixAdd()
     {
         testFix++;
+        if (testFix > testMax)
+        {
+            testFix = testMax;  
+        }
         Calculate(testMax, testPercent, testFix);
     }
 


### PR DESCRIPTION
1. 집중력이 슬롯 전체 개수와 같을 때 무조건 100%
2. 집중력이 슬롯 전체 개수보다 많을 때 불가
3. 출력 후 집중력 리셋되는 버그 고침