### PR TITLE
[feat] 직업따라 다른 플레이어 스탯 설정

### DIFF
--- a/Assets/2.Model/Prefabs/DI/PlayerSpawner.prefab
+++ b/Assets/2.Model/Prefabs/DI/PlayerSpawner.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &5510459050501148847
+--- !u!1 &823561922684919827
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4388436608558180148}
-  - component: {fileID: 3474984078094045531}
+  - component: {fileID: 823561922684919829}
+  - component: {fileID: 823561922684919828}
   m_Layer: 0
   m_Name: PlayerSpawner
   m_TagString: Untagged
@@ -17,27 +17,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4388436608558180148
+--- !u!4 &823561922684919829
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5510459050501148847}
+  m_GameObject: {fileID: 823561922684919827}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 460, y: 440, z: 0}
+  m_LocalPosition: {x: 1160, y: 40, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3474984078094045531
+--- !u!114 &823561922684919828
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5510459050501148847}
+  m_GameObject: {fileID: 823561922684919827}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3226dfc95e5a3324d8f8070e680f999c, type: 3}
@@ -47,3 +47,7 @@ MonoBehaviour:
   blackSmith: {fileID: 2138302730815330478, guid: bcad4bf6f7d04d647a70dfbb4dd3686f, type: 3}
   hunter: {fileID: 5073190857094292040, guid: 7e96564acb5df9548bffd0fc8e5b408c, type: 3}
   scholar: {fileID: 5955792520372026445, guid: 6fe8ea2e323ea2b4997acb94f00dfb59, type: 3}
+  characterStatusSets:
+  - {fileID: 11400000, guid: bb9076fccf51cba4a99df99fd586401c, type: 2}
+  - {fileID: 11400000, guid: f9d837258f88706409787e5fcaa3ece2, type: 2}
+  - {fileID: 11400000, guid: 1c9fb1dc5a178e5499f777614e146d5f, type: 2}

--- a/Assets/3.Script/Develop/KDI/PlayerSpawner.cs
+++ b/Assets/3.Script/Develop/KDI/PlayerSpawner.cs
@@ -11,34 +11,35 @@ public class PlayerSpawner : MonoBehaviour
     [SerializeField] private GameObject hunter;
     [SerializeField] private GameObject scholar;
 
+    [SerializeField] private List<CharacterStatusSet> characterStatusSets;
+
 
     private void Awake()
     {
-        int n = PlayerPrefs.GetInt("PlayerCnt");
-        for (int i = 0; i < n; i++)
+        for (int i = 0; i < PlayerPrefs.GetInt("PlayerCnt"); i++) //플레이 하는 캐릭터 수만큼 반복 생성
         {
+            GameObject player;
+            int x; 
             if (PlayerPrefs.GetString(string.Format("Class{0}", i)).Equals("대장장이"))
             {
-                GameObject player = Instantiate(blackSmith, startPos, Quaternion.identity);
-                player.AddComponent<PlayerController>();
-                player.GetComponent<PlayerController>().order = i+1;  //순서 넣어주기
+                player = Instantiate(blackSmith, startPos, Quaternion.identity);
+                x = 0;
             }
             else if (PlayerPrefs.GetString(string.Format("Class{0}", i)).Equals("사냥꾼"))
             {
-                GameObject player = Instantiate(hunter, startPos, Quaternion.identity);
-                player.AddComponent<PlayerController>();
-                player.GetComponent<PlayerController>().order = i+1; 
-            }
-            else if (PlayerPrefs.GetString(string.Format("Class{0}", i)).Equals("학자"))
-            {
-                GameObject player = Instantiate(scholar, startPos, Quaternion.identity);
-                player.AddComponent<PlayerController>();
-                player.GetComponent<PlayerController>().order = i+1; 
+                player = Instantiate(hunter, startPos, Quaternion.identity);
+                x = 1;
             }
             else
             {
-                Debug.Log("직업 비교 실패");
+                player = Instantiate(scholar, startPos, Quaternion.identity);
+                x = 2;
             }
+            player.AddComponent<PlayerStat>();
+            player.GetComponent<PlayerStat>().name = PlayerPrefs.GetString(string.Format("Name{0}", i)); //이름 연결
+            player.GetComponent<PlayerStat>().order = i; //몇번째 플레이어인지
+            player.GetComponent<PlayerStat>().SetStat(characterStatusSets[x]);
+
         }
     }
 }

--- a/Assets/3.Script/Develop/KDI/PlayerStat.cs
+++ b/Assets/3.Script/Develop/KDI/PlayerStat.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStat : MonoBehaviour
+{
+    [Header("Stat")]
+    public string name;
+    public int order; //플레이어 순서
+    public string className = ""; //클래스 이름
+    public float atk; //공격력
+    public float def; //방어력
+    public float maxHp;
+    public float nowHp;
+    public int intelligence;
+    public int strength;
+    public int awareness;
+    public int speed;
+
+    public float nowExp = 1;
+    public float maxExp = 100;
+    public int Lv = 1;
+
+    public void SetStat(CharacterStatusSet data)
+    {
+        className = data.className;
+        atk = data.atk;
+        def = data.def;
+        maxHp = data.maxHp;
+        nowHp = data.nowHp;
+        intelligence = data.intelligence;
+        strength = data.strength;
+        awareness = data.awareness;
+        speed = data.speed;
+    }
+}

--- a/Assets/3.Script/Develop/KDI/PlayerStat.cs.meta
+++ b/Assets/3.Script/Develop/KDI/PlayerStat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbd9864f1872bed47bd42dc3c7cbe44b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/3.Script/Develop/NSY/Character/PlayerController.cs
+++ b/Assets/3.Script/Develop/NSY/Character/PlayerController.cs
@@ -4,9 +4,8 @@ using UnityEngine;
 
 public class PlayerController : MonoBehaviour
 {
-    public int order; //플레이어 순서
-
     //여기서부터
+    [Header("Node")]
     public HexMember targetNode;
     public HexMember middletargetNode;
     public List<HexMember> targetNodes = new List<HexMember>();


### PR DESCRIPTION
1. 로비에서 고른 직업을 바탕으로 기초 스탯을 다르게 주고 시작한다.
2. spawner는 0, 0, 0에 플레이어를 등장하게 만들었지만 이는 맵 스폰하면서 진이가 수정할 예정.